### PR TITLE
Allow for not rendering on navigator

### DIFF
--- a/jqmNavigator.js
+++ b/jqmNavigator.js
@@ -57,6 +57,16 @@
                 defaultPageContainer:null,
 
                 /**
+                 * Whether to invoke view's render() method.
+                 *
+                 * When using composites views, the entire page is rendered part by part,
+                 * first layout then the page content. In cases like that, rendering on
+                 * navigator causes the page rendering with errors, specially because after
+                 * a view change all widget need to be re-enhanced.
+                 */
+                enableRenderViews: true,
+
+                /**
                  * Pushes view to the stack.
                  *
                  * @param view {Backbone.View}
@@ -70,7 +80,7 @@
                     // Appending the view to the DOM
                     containerViews.pageContainer.append(view.el);
                     // Rendering the view
-                    view.render();
+                    if(this.enableRenderViews) view.render();
 
                     if (!$.mobile.firstPage) {
                         // Adding data-role with page value
@@ -172,7 +182,7 @@
                         // Appending the view to the DOM
                         containerViews.pageContainer.append(view.el);
                         // Rendering the view
-                        view.render();
+                        if(this.enableRenderViews) view.render();
 
                         // Changing page
                         $.mobile.changePage(view.$el, $.extend({
@@ -207,7 +217,7 @@
                         // Appending the view to the DOM
                         containerViews.pageContainer.append(view.el);
                         // Rendering the view
-                        view.render();
+                        if(this.enableRenderViews) view.render();
 
                         // Changing page
                         $.mobile.changePage(view.$el, $.extend({


### PR DESCRIPTION
Hi,

First of all thanks for the plug-in, it has help a lot to integrate my recently backbone application with jqm. During development and setting things up I faced with the problem described below when using the [backbone-boilerplate](http://backboneboilerplate.com/) code where the layout view is rendered first and then the other views composing the page. Hope this could be useful.

When rendering the views partially like in composites views,
rendering on navigator has not much meaning, since the view get
rendered part by part in different moments in time. It is better to
leave that task to external users.

Changes:
    Add configuration option to conditionally render view on navigator

Thanks again
David
